### PR TITLE
Use sed instead of import to extract vars from conf.py

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,15 +9,15 @@ echo "ACTOR: $GITHUB_ACTOR"
 
 echo "==> Preparing..."
 if ! $INPUT_DRY_RUN; then
-    src_branch="$(python -c 'import conf; print(conf.GITHUB_SOURCE_BRANCH)')"
-    dest_branch="$(python -c 'import conf; print(conf.GITHUB_DEPLOY_BRANCH)')"
-    
+    src_branch="$(sed -n "s/^GITHUB_SOURCE_BRANCH\ *=\ *['\"]*\([^'\"]*\).*/\1/p" conf.py)"
+    dest_branch="$(sed -n "s/^GITHUB_DEPLOY_BRANCH\ *=\ *['\"]*\([^'\"]*\).*/\1/p" conf.py)"
+
     git remote add ghpages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
     git fetch ghpages $dest_branch
     git checkout -b $dest_branch --track ghpages/$dest_branch || true
     git pull ghpages $dest_branch || true
     git checkout $src_branch
-    
+
     # Override config so that ghp-import does the right thing.
     printf '\n\nGITHUB_REMOTE_NAME = "ghpages"\nGITHUB_COMMIT_SOURCE = False\n' >> conf.py
 else


### PR DESCRIPTION
Here we replace import conf with sed+regex to extract the relevent
variables. We do this to eliminate an issue with imports in conf.py
that depend on either nikola or requirements.txt installation
before importing conf.py