### PR TITLE
Add apt_install option for binary packages (not available via requirements.txt)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,3 +11,7 @@ inputs:
     description: 'Build without publishing code'
     default: false
     required: false
+  apt_install:
+    descrption: 'Extra APT packages to install from Ubuntu 20.04 repositories, space-separated'
+    default: ''
+    required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ else
     pip install "Nikola[extras]"
 fi
 
-if [ -n "${INPUT_APT_INSTALL}"]; then
+if [ -n "${INPUT_APT_INSTALL}" ]; then
     apt-get update
     apt-get install ${INPUT_APT_INSTALL}
     apt-get clean

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 if [ -n "${INPUT_APT_INSTALL}" ]; then
     apt-get update
-    apt-get install ${INPUT_APT_INSTALL}
+    apt-get install -y ${INPUT_APT_INSTALL}
     apt-get clean
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 : "${INPUT_DRY_RUN:=false}"
+: "${INPUT_APT_INSTALL:=''}"
 
 set -e
 
@@ -30,6 +31,12 @@ if [[ -f "requirements.txt" ]]; then
     pip install -r requirements.txt ghp-import
 else
     pip install "Nikola[extras]"
+fi
+
+if [ -n "${INPUT_APT_INSTALL}"]; then
+    apt-get update
+    apt-get install ${INPUT_APT_INSTALL}
+    apt-get clean
 fi
 
 echo "==> Building site..."


### PR DESCRIPTION
(used like this: https://github.com/eudoxos/brzdime/blob/701ce2f394acd499aab422f284293141683676fd/.github/workflows/main.yml#L15)

I did not find a way to access inputs in Dockerfile, so there are two invocations of APT (one in Dockerfile, one optional in entrypoint.sh).