### PR TITLE
Add git safedir to preparation

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,7 @@ if ! $INPUT_DRY_RUN; then
     src_branch="$(python -c 'import conf; print(conf.GITHUB_SOURCE_BRANCH)')"
     dest_branch="$(python -c 'import conf; print(conf.GITHUB_DEPLOY_BRANCH)')"
     
+    git config --global --add safe.directory /github/workspace
     git remote add ghpages "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
     git fetch ghpages $dest_branch
     git checkout -b $dest_branch --track ghpages/$dest_branch || true


### PR DESCRIPTION
I had an error in my fork that was caused by the git safedir directive:

    ==> Preparing...
    fatal: detected dubious ownership in repository at '/github/workspace'
    To add an exception for this directory, call:
	git config --global --add safe.directory /github/workspace

Adding this made my action run again, so I figured I'd feed it back.